### PR TITLE
feat: improve MCP tool discoverability for MCPSearch

### DIFF
--- a/src/mcp_skills/mcp/tools/find_tool.py
+++ b/src/mcp_skills/mcp/tools/find_tool.py
@@ -77,10 +77,12 @@ async def find(
     project_path: str | None = None,
     limit: int = 10,
 ) -> dict[str, Any]:
-    """Find skills using semantic search, knowledge graph, or metadata queries.
+    """Find and discover skills using semantic search, knowledge graph recommendations, category browsing, or template queries.
+
+    This unified tool provides semantic search, graph-based discovery, category filtering, template listing, and intelligent skill recommendations for Python, TypeScript, JavaScript, Rust, Go, Java, PHP, and Ruby toolchains. Search across categories including testing, deployment, security, architecture, debugging, refactoring, performance, and best-practices.
 
     Unified discovery tool replacing 4 separate tools with a single entry point.
-    Use the 'by' parameter to select search method.
+    Use the 'by' parameter to select search method: semantic, graph, category, template, or recommend.
 
     Search Methods (by parameter):
     - semantic: Vector + graph hybrid search (default, 70% vector + 30% graph)
@@ -90,8 +92,11 @@ async def find(
     - recommend: Get recommendations based on skill or project
 
     Common Use Cases:
-        # Natural language semantic search
+        # Search for testing skills (semantic)
         find(query="pytest testing patterns", by="semantic", limit=5)
+
+        # Find Python testing skills (semantic + toolchain filter)
+        find(query="testing best practices", by="semantic", toolchain="python")
 
         # Graph-based relationship search
         find(query="security", by="graph", toolchain="python")
@@ -99,26 +104,26 @@ async def find(
         # List all categories
         find(by="category")
 
-        # Search within category
+        # Browse testing category
         find(by="category", category="testing", limit=10)
 
-        # List templates
+        # List templates for skill creation
         find(by="template")
 
-        # Project-based recommendations
+        # Recommend skills for project
         find(by="recommend", project_path="/path/to/project", limit=5)
 
-        # Skill-based recommendations
+        # Recommend related skills
         find(by="recommend", skill_id="pytest-skill", limit=5)
 
     Args:
-        query: Search query for semantic/graph modes
-        by: Search method (semantic|graph|category|template|recommend)
-        toolchain: Filter by toolchain (python, typescript, rust, etc.)
-        category: Filter by category or specify category for category mode
+        query: Search query for semantic/graph modes (natural language or keywords)
+        by: Search method - valid values: semantic, graph, category, template, recommend (default: semantic)
+        toolchain: Filter by toolchain - supported: python, typescript, javascript, rust, go, java, php, ruby
+        category: Filter by category - available: testing, deployment, security, architecture, debugging, refactoring, performance, best-practices
         tags: Filter by tags (AND logic - skills must have all specified tags)
-        skill_id: Base skill ID for recommend mode
-        project_path: Project path for recommend mode
+        skill_id: Base skill ID for recommend mode (finds related skills)
+        project_path: Project path for recommend mode (detects toolchains and recommends skills)
         limit: Maximum results (1-50, default: 10)
 
     Returns:

--- a/src/mcp_skills/mcp/tools/skill_tool.py
+++ b/src/mcp_skills/mcp/tools/skill_tool.py
@@ -71,33 +71,66 @@ async def skill(
     skill_id: str | None = None,
     force: bool = False,
 ) -> dict[str, Any]:
-    """Perform skill read operations.
+    """Read skill details, view skill instructions and examples, or rebuild search indices for skill discovery.
 
-    Actions:
-    - read: Get complete skill details
-    - reindex: Rebuild search indices
+    This tool provides read access to skill metadata, instructions, examples, and dependencies. Use action="read" to view complete skill details including instructions and code examples. Use action="reindex" to rebuild vector search indices and knowledge graph for updated skill discovery.
+
+    Available Actions:
+    - read: Get complete skill details, view instructions, examples, and metadata
+    - reindex: Rebuild search indices (vector store + knowledge graph) for skill discovery
 
     Note: Write operations (create/update/delete) are available via CLI only.
-    Use `mcp-skillset build-skill` for creating skills.
+    Use `mcp-skillset build-skill` for creating skills, or edit skill files directly for updates.
 
     Args:
-        action: Operation to perform (read|reindex)
-        skill_id: Skill ID for read
-        force: Force reindex even if up-to-date
+        action: Operation to perform - valid values: read, reindex
+        skill_id: Skill ID for read action (required when action="read")
+        force: Force reindex even if indices are up-to-date (optional, default: False)
 
     Returns:
-        Dict with status and result data
+        Dict with status and result data:
+        - For read: Returns skill metadata, instructions, examples, tags, category, toolchain, dependencies
+        - For reindex: Returns indexing statistics (indexed_count, vector_store_size, graph_nodes, graph_edges)
+
+    Common Use Cases:
+        # Get skill details and instructions
+        skill(action="read", skill_id="pytest-skill")
+
+        # View skill examples and code snippets
+        skill(action="read", skill_id="fastapi-testing")
+
+        # Rebuild search index after skill updates
+        skill(action="reindex", force=True)
+
+        # Incremental reindex (only if needed)
+        skill(action="reindex")
 
     Examples:
-        >>> # Read skill
+        >>> # Read skill details
         >>> skill(action="read", skill_id="pytest-skill")
         {
             "status": "completed",
-            "skill": {"id": "pytest-skill", "name": "pytest", ...}
+            "skill": {
+                "id": "pytest-skill",
+                "name": "pytest",
+                "description": "Testing patterns with pytest",
+                "category": "testing",
+                "tags": ["python", "testing", "tdd"],
+                "instructions": "...",
+                "examples": [...]
+            }
         }
 
         >>> # Reindex all skills
         >>> skill(action="reindex", force=True)
+        {
+            "status": "completed",
+            "action": "reindex",
+            "indexed_count": 42,
+            "vector_store_size": 1024,
+            "graph_nodes": 50,
+            "graph_edges": 120
+        }
 
     """
     try:


### PR DESCRIPTION
## Summary

- Enhanced docstrings for `find()` and `skill()` MCP tools with comprehensive semantic keywords
- Added enumeration of all valid parameter values (`by`, `toolchain`, `category`, `action`) in descriptions
- Included domain-specific terms (python, typescript, testing, deployment, security)
- Added natural language use case patterns for better MCPSearch matching

## Changes

### `find_tool.py`
- Front-loaded keywords in first paragraph: semantic search, knowledge graph, recommendations, category browsing, template queries
- Enumerated all `by` parameter values: semantic, graph, category, template, recommend
- Listed all toolchains: python, typescript, javascript, rust, go, java, php, ruby
- Listed all categories: testing, deployment, security, architecture, debugging, refactoring, performance, best-practices

### `skill_tool.py`
- Added keywords: read, view, instructions, examples, rebuild, search indices, discovery
- Enumerated all `action` values: read, reindex
- Added clear use case patterns

## Test plan

- [x] Docstring-only changes - no functional code modified
- [x] Python syntax validation passed
- [ ] MCPSearch discoverability testing with queries like "recommend skills", "search templates", "view skill details"

## Metrics

- **Target:** 85%+ MCPSearch readiness (up from 65%)
- **Method:** Comprehensive keyword coverage for common user queries

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)